### PR TITLE
Fixes a bug that is seen after deactivating ModeSwitch

### DIFF
--- a/src/libhidpp/hidpp20/ProfileFormat.cpp
+++ b/src/libhidpp/hidpp20/ProfileFormat.cpp
@@ -388,7 +388,7 @@ const std::map<std::string, SettingDesc> ProfileFormat::ModeSettings = {
 };
 
 const EnumDesc ProfileFormat::SpecialActions = {
-	{ "DeactivatedSpecial", 0 },
+	{ "Deactivated", 0 },
 	{ "WheelLeft", 1 },
 	{ "WheelRight", 2 },
 	{ "ResolutionNext", 3 },

--- a/src/libhidpp/hidpp20/ProfileFormat.cpp
+++ b/src/libhidpp/hidpp20/ProfileFormat.cpp
@@ -388,6 +388,7 @@ const std::map<std::string, SettingDesc> ProfileFormat::ModeSettings = {
 };
 
 const EnumDesc ProfileFormat::SpecialActions = {
+	{ "DeactivatedSpecial", 0 },
 	{ "WheelLeft", 1 },
 	{ "WheelRight", 2 },
 	{ "ResolutionNext", 3 },


### PR DESCRIPTION
I have a Logitech G102 mouse. In my previous configuration, I had used LGS under Windows 10 to assign one of the side buttons to G-shift ("ModeSwitch" according to ProfileFormat.cpp). I got rid of my customization under LGS and assigned all the buttons to their default roles. Apparently, the on-board memory of the mouse remembers the previously assigned G-shifted roles of the buttons. As a result of that, running `sudo ./hidpp-persistent-profiles -vinfo /dev/hidraw1 read lgs-default.xml` would fail with the following message:


    [info:feature] Feature [0x8100] OnboardProfiles has index 0x0f
    [info:feature] Feature [0x8100] OnboardProfiles has index 0x0f
    terminate called after throwing an instance of 'std::runtime_error'
      what():  value is not in enum
    zsh: abort      sudo ./hidpp-persistent-profiles -vinfo /dev/hidraw1 read lgs-default.xml

With my patch, the program runs without failing, and shows the following XML:

    <profiles>
        <profile>
            <dir_unknown>0</dir_unknown>
            <enabled>true</enabled>
            <modes>
                <mode>
                    <dpi>400</dpi>
                </mode>
                <mode>
                    <dpi>800</dpi>
                </mode>
                <mode>
                    <dpi>1000</dpi>
                </mode>
                <mode>
                    <dpi>1600</dpi>
                </mode>
                <mode>
                    <dpi>2500</dpi>
                </mode>
            </modes>
            <angle_snapping>false</angle_snapping>
            <color>ffffff</color>
            <default_dpi>2</default_dpi>
            <logo_effect>
                <brightness>49</brightness>
                <period>12000</period>
                <type>Cycle</type>
            </logo_effect>
            <name>Profile 1</name>
            <report_rate>1</report_rate>
            <revision>71</revision>
            <side_effect>
                <brightness>49</brightness>
                <period>12000</period>
                <type>Cycle</type>
            </side_effect>
            <switched_dpi>0</switched_dpi>
            <buttons>
                <mouse-button>0</mouse-button>
                <mouse-button>1</mouse-button>
                <mouse-button>2</mouse-button>
                <mouse-button>3</mouse-button>
                <mouse-button>4</mouse-button>
                <special>ResolutionCycle</special>
                <mouse-button>0</mouse-button>
                <mouse-button>1</mouse-button>
                <mouse-button>2</mouse-button>
                <special>DeactivatedSpecial</special>
                <key modifiers="LeftControl">0</key>
                <key modifiers="LeftMeta">E</key>
            </buttons>
        </profile>
    </profiles>

This new configuration can be written to the mouse and read back again without errors.