### PR TITLE
Fix some missing includes

### DIFF
--- a/src/libhidpp/hidpp/Device.h
+++ b/src/libhidpp/hidpp/Device.h
@@ -21,6 +21,7 @@
 
 #include <hidpp/defs.h>
 #include <hidpp/Report.h>
+#include <string>
 #include <tuple>
 
 namespace HIDPP

--- a/src/libhidpp/hidpp/Report.cpp
+++ b/src/libhidpp/hidpp/Report.cpp
@@ -21,6 +21,7 @@
 #include <hidpp10/defs.h>
 #include <hidpp20/defs.h>
 #include <algorithm>
+#include <stdexcept>
 
 using namespace HIDPP;
 

--- a/src/libhidpp/hidpp/Setting.h
+++ b/src/libhidpp/hidpp/Setting.h
@@ -21,6 +21,7 @@
 
 #include <vector>
 #include <map>
+#include <stdexcept>
 
 #include <hidpp/Enum.h>
 

--- a/src/libhidpp/hidpp10/IMemory.cpp
+++ b/src/libhidpp/hidpp10/IMemory.cpp
@@ -24,6 +24,7 @@
 #include <misc/Endian.h>
 
 #include <algorithm>
+#include <stdexcept>
 
 using namespace HIDPP;
 using namespace HIDPP10;

--- a/src/libhidpp/hidpp10/IProfile.cpp
+++ b/src/libhidpp/hidpp10/IProfile.cpp
@@ -21,6 +21,8 @@
 #include <hidpp10/Device.h>
 #include <hidpp10/defs.h>
 
+#include <stdexcept>
+
 using namespace HIDPP;
 using namespace HIDPP10;
 

--- a/src/libhidpp/hidpp10/IResolution.cpp
+++ b/src/libhidpp/hidpp10/IResolution.cpp
@@ -24,6 +24,8 @@
 
 #include <misc/Endian.h>
 
+#include <stdexcept>
+
 using namespace HIDPP10;
 
 IResolution0::IResolution0 (Device *dev, const Sensor *sensor):


### PR DESCRIPTION
Without these, the build fails on GCC 10.2 with errors like
> 'runtime_error' is not a member of 'std'.

There are still a couple of warnings, which I didn't try to fix.
Both look valid but non-serious:

```[74/99] Building CXX object src/tools/CMakeFiles/hidpp10-load-temp-profile.dir/hidpp10-load-temp-profile.cpp.o
../src/tools/hidpp10-load-temp-profile.cpp: In function ‘int main(int, char**)’:
../src/tools/hidpp10-load-temp-profile.cpp:119:67: warning: narrowing conversion of ‘((profile_format.std::unique_ptr<HIDPP::AbstractProfileFormat>::operator->()->HIDPP::AbstractProfileFormat::size() + 1) / 2)’ from ‘size_t’ {aka ‘long unsigned int’} to ‘unsigned int’ [-Wnarrowing]
  119 |   HIDPP::Address macro_address { 0, 0, (profile_format->size ()+1)/2 };
```

```../src/tools/hidpp20-led-control.cpp: In function ‘int main(int, char**)’:
../src/tools/hidpp20-led-control.cpp:244:11: warning: unused variable ‘mode’ [-Wunused-variable]
  244 |      auto mode = Modes.value(argv[first_arg+1]);
      |           ^~~~
```