### PR TITLE
Fixed missing include

### DIFF
--- a/src/tools/hidpp20-raw-touchpad-driver.cpp
+++ b/src/tools/hidpp20-raw-touchpad-driver.cpp
@@ -20,6 +20,7 @@
 #include <vector>
 #include <map>
 #include <cassert>
+#include <thread>
 
 #include "common/common.h"
 #include "common/CommonOptions.h"


### PR DESCRIPTION
The build failed on GCC 11.1.0, because there was a missing include for threads.