### PR TITLE
Fix exceptions not publicly inheriting from std::exception

### DIFF
--- a/src/libhidpp/hidpp/Report.h
+++ b/src/libhidpp/hidpp/Report.h
@@ -69,7 +69,7 @@ public:
 	/**
 	 * Exception for reports with invalid report ID.
 	 */
-	class InvalidReportID: std::exception
+	class InvalidReportID: public std::exception
 	{
 	public:
 		InvalidReportID ();
@@ -79,7 +79,7 @@ public:
 	 * Exception for reports where the length is not the expected one
 	 * from the report type.
 	 */
-	class InvalidReportLength: std::exception
+	class InvalidReportLength: public std::exception
 	{
 	public:
 		InvalidReportLength ();


### PR DESCRIPTION
This is a minor fix but the lack of public inheritance prevents them from being caught with std::exception references. The unsuspecting user will see their app crash with an uncaught exception.