### PR TITLE
Support HID++ error data and non-long errors

### DIFF
--- a/src/libhidpp/hidpp/Report.cpp
+++ b/src/libhidpp/hidpp/Report.cpp
@@ -258,8 +258,7 @@ bool Report::checkErrorMessage20 (uint8_t *feature_index,
 				  uint8_t *error_code,
 				  std::vector<uint8_t> *error_data) const
 {
-	if (static_cast<Type> (_data[Offset::Type]) != Long ||
-	    _data[Offset::SubID] != HIDPP20::ErrorMessage)
+	if (_data[Offset::SubID] != HIDPP20::ErrorMessage)
 		return false;
 
 	if (feature_index)

--- a/src/libhidpp/hidpp/Report.cpp
+++ b/src/libhidpp/hidpp/Report.cpp
@@ -255,7 +255,8 @@ bool Report::checkErrorMessage10 (uint8_t *sub_id,
 bool Report::checkErrorMessage20 (uint8_t *feature_index,
 				  unsigned int *function,
 				  unsigned int *sw_id,
-				  uint8_t *error_code) const
+				  uint8_t *error_code,
+				  std::vector<uint8_t> *error_data) const
 {
 	if (static_cast<Type> (_data[Offset::Type]) != Long ||
 	    _data[Offset::SubID] != HIDPP20::ErrorMessage)
@@ -269,6 +270,15 @@ bool Report::checkErrorMessage20 (uint8_t *feature_index,
 		*sw_id = _data[4] & 0x0F;
 	if (error_code)
 		*error_code = _data[5];
+
+	if (error_data)
+	{
+		size_t offset = _data.size() - 1;
+		while(offset >= 6 && _data[offset] == 0x00)		// Look for the last non-zero byte
+			--offset;
+		*error_data = { _data.data() + 6, _data.data() + offset + 1 };	// Copy the error data
+	}
+
 	return true;
 }
 

--- a/src/libhidpp/hidpp/Report.h
+++ b/src/libhidpp/hidpp/Report.h
@@ -252,12 +252,13 @@ public:
 	 * \param function	The function of the report responsible for the error.
 	 * \param sw_id		The software ID of the report responsible for the error.
 	 * \param error_code	The error code of the error.
+	 * \param error_data	Additional error data sent by the device.
 	 *
 	 * \return \c true if the report is a HID++ 2.0 error, \c false otherwise.
 	 *
 	 * \sa HIDPP20::Error
 	 */
-	bool checkErrorMessage20 (uint8_t *feature_index, unsigned int *function, unsigned int *sw_id, uint8_t *error_code) const;
+	bool checkErrorMessage20 (uint8_t *feature_index, unsigned int *function, unsigned int *sw_id, uint8_t *error_code, std::vector<uint8_t> *error_data = nullptr) const;
 
 	/**\}*/
 

--- a/src/libhidpp/hidpp/SimpleDispatcher.cpp
+++ b/src/libhidpp/hidpp/SimpleDispatcher.cpp
@@ -138,6 +138,7 @@ Report SimpleDispatcher::CommandResponse::get (int timeout)
 		}
 		unsigned int function, swid;
 		uint8_t sub_id, address, feature, error_code;
+		std::vector<uint8_t> error_data;
 		if (response.checkErrorMessage10 (&sub_id, &address, &error_code)) {
 			if (sub_id == report.subID () && address == report.address ())
 				throw HIDPP10::Error (error_code);
@@ -146,9 +147,9 @@ Report SimpleDispatcher::CommandResponse::get (int timeout)
 				continue;
 			}
 		}
-		if (response.checkErrorMessage20 (&feature, &function, &swid, &error_code)) {
+		if (response.checkErrorMessage20 (&feature, &function, &swid, &error_code, &error_data)) {
 			if (feature == report.featureIndex () && function == report.function () && swid == report.softwareID ())
-				throw HIDPP20::Error (error_code);
+				throw HIDPP20::Error (error_code, std::move(error_data));
 			else {
 				debug << "Ignored HID++2.0 error response." << std::endl;
 				continue;

--- a/src/libhidpp/hidpp20/Error.cpp
+++ b/src/libhidpp/hidpp20/Error.cpp
@@ -25,6 +25,13 @@ Error::Error (uint8_t error_code):
 {
 }
 
+Error::Error (uint8_t error_code, std::vector<uint8_t> error_data):
+	_error_code (error_code),
+	_error_data (std::move(error_data))
+{
+}
+
+
 const char *Error::what () const noexcept
 {
 	switch (_error_code) {

--- a/src/libhidpp/hidpp20/Error.h
+++ b/src/libhidpp/hidpp20/Error.h
@@ -20,6 +20,7 @@
 #define LIBHIDPP_HIDPP20_ERROR_H
 
 #include <stdexcept>
+#include <vector>
 
 #include <hidpp20/defs.h>
 
@@ -44,12 +45,15 @@ public:
 	};
 
 	Error (uint8_t error_code);
+	Error (uint8_t error_code, std::vector<uint8_t> error_data);
 
 	virtual const char *what () const noexcept;
 	uint8_t errorCode () const;
+	const std::vector<uint8_t>& errorData () const { return _error_data; }
 
 private:
 	uint8_t _error_code;
+	std::vector<uint8_t> _error_data;
 };
 
 }


### PR DESCRIPTION
This fixes a bug that we previously talked about in https://github.com/cvuchener/hidpp/issues/12#issuecomment-856414365 and adds a small feature to allow client applications to read the error bytes that HID++ errors can contain (quite helpful to retrieve details about the errors for certain HID++ functions).

The two commits are unrelated, so they could be separated if desired.