### PR TITLE
Windows build: Add CMakeSettings.json and improve documentation

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,92 @@
+﻿{
+  "configurations": [
+    {
+      "name": "x64-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "variables": [
+        {
+          "name": "BUILD_TOOLS",
+          "value": "False",
+          "type": "BOOL"
+        },
+        {
+          "name": "BUILD_SHARED_LIBS",
+          "value": "False",
+          "type": "BOOL"
+        }
+      ]
+    },
+    {
+      "name": "x64-Release",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "variables": [
+        {
+          "name": "BUILD_SHARED_LIBS",
+          "value": "False",
+          "type": "BOOL"
+        },
+        {
+          "name": "BUILD_TOOLS",
+          "value": "False",
+          "type": "BOOL"
+        }
+      ]
+    },
+    {
+      "name": "x86-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "msvc_x86" ],
+      "variables": [
+        {
+          "name": "BUILD_SHARED_LIBS",
+          "value": "False",
+          "type": "BOOL"
+        },
+        {
+          "name": "BUILD_TOOLS",
+          "value": "False",
+          "type": "BOOL"
+        }
+      ]
+    },
+    {
+      "name": "x86-Release",
+      "generator": "Ninja",
+      "configurationType": "RelWithDebInfo",
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "msvc_x86" ],
+      "variables": [
+        {
+          "name": "BUILD_SHARED_LIBS",
+          "value": "False",
+          "type": "BOOL"
+        },
+        {
+          "name": "BUILD_TOOLS",
+          "value": "False",
+          "type": "BOOL"
+        }
+      ]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -30,7 +30,40 @@ make
 
 Library and tools can be installed with `make install`.
 
-When building with Microsoft Visual C++ (MSVC), you must also provide a library for **getopt** (vcpkg has [one](https://vcpkg.info/port/getopt)). Shared library builds are not currently supported with MSVC, use `-DBUILD_SHARED_LIBS=OFF` when configuring cmake.
+### Building with Visual Studio
+
+For building hidpp with Visual Studio (tested with Visual Studio 2019 16.11.5) a `CMakeSettings.json` file is included which contains Debug and Release configurations each for the x64 and x86 platforms.
+By default `BUILD_SHARED_LIBS` and `BUILD_TOOLS` are disabled, the former because shared library builds are not currently supported for MSVC (see #19), the latter because it requires extra dependencies.
+
+Building the tools requires installing the **getopt** dependency first.
+The easiest way of doing so is by installing [this one](https://vcpkg.info/port/getopt) available through [vcpkg](https://vcpkg.io/):
+
+```
+vcpkg install getopt:x86-windows
+vcpkg install getopt:x64-windows
+```
+
+With getopt installed, enable the `BUILD_TOOLS` variable in the CMake Settings for the desired configurations, regenerate the CMake cache, and then build.
+
+Manually building from a Visual Studio Developer console is also supported:
+
+```
+mkdir build
+cd build
+cmake -DBUILD_SHARED_LIBS=OFF -DBUILD_TOOLS=OFF ..
+# or, with tools support:
+cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_TOOLCHAIN_FILE=<path to vcpkg>\scripts\buildsystems\vcpkg.cmake ..
+start hidpp.sln
+```
+
+An alternative is to use CMake's Ninja generator:
+
+```
+cmake -G ninja -DBUILD_SHARED_LIBS=OFF -DBUILD_TOOLS=OFF ..
+# or, with tools support:
+cmake -G ninja -DBUILD_SHARED_LIBS=OFF -DCMAKE_TOOLCHAIN_FILE=<path to vcpkg>\scripts\buildsystems\vcpkg.cmake ..
+ninja
+```
 
 ### CMake options
 


### PR DESCRIPTION
As a follow-up to #19 and #5 here are a few additions that make building hidpp on Windows a bit easier. The `CMakeSettings.json` allows people to open the project folder directly in Visual Studio and start building. I've also updated the `README.md` with some instructions for building the project and installing the _getopt_ dependency.