### PR TITLE
Fix memory leak in Windows DeviceData

### DIFF
--- a/src/libhidpp/hid/windows/DeviceData.cpp
+++ b/src/libhidpp/hid/windows/DeviceData.cpp
@@ -123,6 +123,11 @@ DeviceEnumerator::DeviceEnumerator (const GUID *interface_class):
 	}
 }
 
+DeviceEnumerator::~DeviceEnumerator() {
+	if (_hdevinfo != NULL && _hdevinfo != INVALID_HANDLE_VALUE)
+		SetupDiDestroyDeviceInfoList(_hdevinfo);
+}
+
 std::unique_ptr<DeviceInterfaceData> DeviceEnumerator::get (DWORD index)
 {
 	DWORD err;

--- a/src/libhidpp/hid/windows/DeviceData.h
+++ b/src/libhidpp/hid/windows/DeviceData.h
@@ -61,6 +61,7 @@ class DeviceEnumerator
 {
 public:
 	DeviceEnumerator (const GUID *interface_class);
+	~DeviceEnumerator ();
 
 	std::unique_ptr<DeviceInterfaceData> get (DWORD index);
 


### PR DESCRIPTION
Destroy DeviceInfo list when DeviceEnumerator is destroyed.