### PR TITLE
Fix compilation under Fedora 38

### DIFF
--- a/src/libhidpp/hid/UsageStrings.h
+++ b/src/libhidpp/hid/UsageStrings.h
@@ -20,6 +20,7 @@
 #define LIBHIDPP_HID_USAGE_STRINGS_H
 
 #include <string>
+#include <cstdint>
 
 namespace HID
 {

--- a/src/libhidpp/hidpp/Setting.h
+++ b/src/libhidpp/hidpp/Setting.h
@@ -22,6 +22,7 @@
 #include <vector>
 #include <map>
 #include <stdexcept>
+#include <cstdint>
 
 #include <hidpp/Enum.h>
 

--- a/src/libhidpp/hidpp20/UnsupportedFeature.h
+++ b/src/libhidpp/hidpp20/UnsupportedFeature.h
@@ -20,6 +20,7 @@
 #define LIBHIDPP_HIDPP20_UNSUPPORTED_FEATURE_H
 
 #include <stdexcept>
+#include <cstdint>
 
 namespace HIDPP20
 {

--- a/src/libhidpp/hidpp20/defs.h
+++ b/src/libhidpp/hidpp20/defs.h
@@ -19,6 +19,8 @@
 #ifndef LIBHIDPP_HIDPP20_DEFS_H
 #define LIBHIDPP_HIDPP20_DEFS_H
 
+#include <cstdint>
+
 namespace HIDPP20
 {
 	constexpr uint8_t ErrorMessage = 0xFF;


### PR DESCRIPTION
`g++` complains about all the uintX_t data types being undeclared.

Build log on my system:
[errors.txt](https://github.com/cvuchener/hidpp/files/11614535/errors.txt)
